### PR TITLE
Error handling ui for add money and update cc errors

### DIFF
--- a/intercom/src/components/Billing/AddToBalance.js
+++ b/intercom/src/components/Billing/AddToBalance.js
@@ -98,18 +98,18 @@ class AddToBalance extends Component {
         console.log('userId: ', userId);
         try{
             // this.setState({processing: true, buttonText:'Processing...'})
-            // // the body sent to the /api/billing/addMoneyIOS endpoint should contain entries for userId and amountToAdd
+            // // the body sent to the /api/billing/addMoney endpoint should contain entries for userId and amountToAdd
             // const amountToAdd = this.state.amountToAdd // in dollars
-            // const addMoneyIOSRes = await axios.post(`${host}/api/billing/addMoney`,{'userId':userId, 'amountToAdd':amountToAdd});
-            // // console.log('addMoneyIOSRes: ', addMoneyIOSRes);
+            // const addMoneyRes = await axios.post(`${host}/api/billing/addMoney`,{'userId':userId, 'amountToAdd':amountToAdd});
+            // // console.log('addMoneyRes: ', addMoneyRes);
 
-            // if (addMoneyIOSRes.data.errorMessage) {
-            //     // console.log('errorMessage: ',addMoneyIOSRes.data.errorMessage);
-            //     this.setState({errorMessage:addMoneyIOSRes.data.errorMessage});
+            // if (addMoneyRes.data.errorMessage) {
+            //     // console.log('errorMessage: ',addMoneyRes.data.errorMessage);
+            //     this.setState({errorMessage:addMoneyRes.data.errorMessage});
             //     console.log('this.state.errorMessage: ',this.state.errorMessage )
             // };
 
-            // const updatedAccountBalance = addMoneyIOSRes.data.updatedAccountBalance;
+            // const updatedAccountBalance = addMoneyRes.data.updatedAccountBalance;
             // console.log('updatedAccountBalance: ', updatedAccountBalance);
 
             // this.setState({amountToAdd:0, processing: false, buttonText:'Add'});

--- a/intercom/src/components/Billing/AddToBalance.js
+++ b/intercom/src/components/Billing/AddToBalance.js
@@ -97,6 +97,25 @@ class AddToBalance extends Component {
         const userId = localStorage.getItem('userId');
         console.log('userId: ', userId);
         try{
+            // this.setState({processing: true, buttonText:'Processing...'})
+            // // the body sent to the /api/billing/addMoneyIOS endpoint should contain entries for userId and amountToAdd
+            // const amountToAdd = this.state.amountToAdd // in dollars
+            // const addMoneyIOSRes = await axios.post(`${host}/api/billing/addMoney`,{'userId':userId, 'amountToAdd':amountToAdd});
+            // // console.log('addMoneyIOSRes: ', addMoneyIOSRes);
+
+            // if (addMoneyIOSRes.data.errorMessage) {
+            //     // console.log('errorMessage: ',addMoneyIOSRes.data.errorMessage);
+            //     this.setState({errorMessage:addMoneyIOSRes.data.errorMessage});
+            //     console.log('this.state.errorMessage: ',this.state.errorMessage )
+            // };
+
+            // const updatedAccountBalance = addMoneyIOSRes.data.updatedAccountBalance;
+            // console.log('updatedAccountBalance: ', updatedAccountBalance);
+
+            // this.setState({amountToAdd:0, processing: false, buttonText:'Add'});
+            // this.props.toggleChangeAddToBalance();
+            // this.props.handleAddToBalance();
+
             this.setState({processing: true, buttonText:'Processing...'})
             // the body sent to the /api/billing/addMoneyIOS endpoint should contain entries for userId and amountToAdd
             const amountToAdd = this.state.amountToAdd // in dollars
@@ -106,15 +125,17 @@ class AddToBalance extends Component {
             if (addMoneyIOSRes.data.errorMessage) {
                 // console.log('errorMessage: ',addMoneyIOSRes.data.errorMessage);
                 this.setState({errorMessage:addMoneyIOSRes.data.errorMessage});
-                console.log('this.state.errorMessage: ',this.state.errorMessage )
+                // console.log('this.state.errorMessage: ',this.state.errorMessage )
+            } else{
+                const updatedAccountBalance = addMoneyIOSRes.data.updatedAccountBalance;
+                // console.log('updatedAccountBalance: ', updatedAccountBalance);
+
+                this.setState({amountToAdd:0, processing: false, buttonText:'Add'});
+                this.props.toggleChangeAddToBalance();
+                this.props.handleAddToBalance();
             };
 
-            const updatedAccountBalance = addMoneyIOSRes.data.updatedAccountBalance;
-            console.log('updatedAccountBalance: ', updatedAccountBalance);
-
-            this.setState({amountToAdd:0, processing: false, buttonText:'Add'});
-            this.props.toggleChangeAddToBalance();
-            this.props.handleAddToBalance();
+            
 
         } catch(err) {
             console.log('err: ', err);
@@ -125,28 +146,33 @@ class AddToBalance extends Component {
 
     render() {
         return (
-            <div className="input-group add-balance-div">
-                <input
-                    placeholder='Amount to add: $'
-                    type = 'number'
-                    name = 'amountToAdd'
-                    value = {this.state.amountToAdd}
-                    onChange = {this.inputChangeHandler}
-                    className='form-control add-balance-input'
-                />
-                <span className="input-group-btn">
-                    <button 
-                        className="btn btn-default" 
-                        onClick = {this.chargeCreditCardAndUpdateAccountBalance} 
-                        type = 'submit'
-                        disabled={this.state.amountToAdd === 0 || this.state.processing === true}
-                    > 
-                        {this.state.buttonText} 
-                    </button>
-                </span>                
-                <div style = {{marginBottom:'10px'}}>
+            <div>
+
+                <div className="input-group add-balance-div">
+                    <input
+                        placeholder='Amount to add: $'
+                        type = 'number'
+                        name = 'amountToAdd'
+                        value = {this.state.amountToAdd}
+                        onChange = {this.inputChangeHandler}
+                        className='form-control add-balance-input'
+                    />
+                    <span className="input-group-btn">
+                        <button 
+                            className="btn btn-default" 
+                            onClick = {this.chargeCreditCardAndUpdateAccountBalance} 
+                            type = 'submit'
+                            disabled={this.state.amountToAdd === 0 || this.state.processing === true}
+                        > 
+                            {this.state.buttonText} 
+                        </button>
+                    </span>                                                              
+                </div>
+
+                <div style = {{marginBottom:'10px', border:'1px solid black', height:'200px'}}>
                     {this.state.errorMessage}
-                </div>                            
+                </div> 
+                
             </div>
         )
     }

--- a/intercom/src/components/Billing/AddToBalance.js
+++ b/intercom/src/components/Billing/AddToBalance.js
@@ -117,15 +117,22 @@ class AddToBalance extends Component {
             // this.props.handleAddToBalance();
             
             this.setState({processing: true, buttonText:'Processing...'})
-            // the body sent to the /api/billing/addMoneyIOS endpoint should contain entries for userId and amountToAdd
+            // the body sent to the /api/billing/addMoney endpoint should contain entries for userId and amountToAdd
             const amountToAdd = this.state.amountToAdd // in dollars
             const addMoneyRes = await axios.post(`${host}/api/billing/addMoney`,{'userId':userId, 'amountToAdd':amountToAdd});
-            // console.log('addMoneyIOSRes: ', addMoneyIOSRes);
+            // console.log('addMoneyRes: ', addMoneyRes);
 
             if (addMoneyRes.data.errorMessage) {
-                // console.log('errorMessage: ',addMoneyIOSRes.data.errorMessage);
-                this.setState({errorMessage:addMoneyRes.data.errorMessage, processing: false, buttonText:'Add'});
-                // console.log('this.state.errorMessage: ',this.state.errorMessage )
+                if (addMoneyRes.data.errorMessage ===  "Invalid source object: must be a dictionary or a non-empty string. See API docs at https://stripe.com/docs'") {
+                    console.log('gottem')
+                    this.setState({errorMessage:"User must have credit card on file to add money.", processing: false, buttonText:'Add'});
+                }
+                else{
+                    console.log('errorMessage: ',addMoneyRes.data.errorMessage);
+                    this.setState({errorMessage:addMoneyRes.data.errorMessage, processing: false, buttonText:'Add'});
+                    // console.log('this.state.errorMessage: ',this.state.errorMessage )
+                }
+                
             } else{
                 const updatedAccountBalance = addMoneyRes.data.updatedAccountBalance;
                 // console.log('updatedAccountBalance: ', updatedAccountBalance);

--- a/intercom/src/components/Billing/AddToBalance.js
+++ b/intercom/src/components/Billing/AddToBalance.js
@@ -14,7 +14,7 @@ class AddToBalance extends Component {
         super(props);
         this.state = {
             amountToAdd:0,
-            errorMessage: '',
+            errorMessage: null,
             processing: false,
             buttonText:'Add'
         };
@@ -115,24 +115,25 @@ class AddToBalance extends Component {
             // this.setState({amountToAdd:0, processing: false, buttonText:'Add'});
             // this.props.toggleChangeAddToBalance();
             // this.props.handleAddToBalance();
-
+            
             this.setState({processing: true, buttonText:'Processing...'})
             // the body sent to the /api/billing/addMoneyIOS endpoint should contain entries for userId and amountToAdd
             const amountToAdd = this.state.amountToAdd // in dollars
-            const addMoneyIOSRes = await axios.post(`${host}/api/billing/addMoney`,{'userId':userId, 'amountToAdd':amountToAdd});
+            const addMoneyRes = await axios.post(`${host}/api/billing/addMoney`,{'userId':userId, 'amountToAdd':amountToAdd});
             // console.log('addMoneyIOSRes: ', addMoneyIOSRes);
 
-            if (addMoneyIOSRes.data.errorMessage) {
+            if (addMoneyRes.data.errorMessage) {
                 // console.log('errorMessage: ',addMoneyIOSRes.data.errorMessage);
-                this.setState({errorMessage:addMoneyIOSRes.data.errorMessage});
+                this.setState({errorMessage:addMoneyRes.data.errorMessage, processing: false, buttonText:'Add'});
                 // console.log('this.state.errorMessage: ',this.state.errorMessage )
             } else{
-                const updatedAccountBalance = addMoneyIOSRes.data.updatedAccountBalance;
+                const updatedAccountBalance = addMoneyRes.data.updatedAccountBalance;
                 // console.log('updatedAccountBalance: ', updatedAccountBalance);
 
-                this.setState({amountToAdd:0, processing: false, buttonText:'Add'});
+                this.setState({amountToAdd:0, processing: false, buttonText:'Add', errorMessage:null});
                 this.props.toggleChangeAddToBalance();
                 this.props.handleAddToBalance();
+
             };
 
             
@@ -168,10 +169,14 @@ class AddToBalance extends Component {
                         </button>
                     </span>                                                              
                 </div>
-
-                <div style = {{marginBottom:'10px', border:'1px solid black', height:'200px'}}>
-                    {this.state.errorMessage}
-                </div> 
+                {this.state.errorMessage
+                    ?
+                    <div style = {{marginBottom:'20px', color:'red', height:'20px'}}>
+                        {this.state.errorMessage}
+                    </div>
+                    :null
+                }
+                 
                 
             </div>
         )

--- a/intercom/src/components/Billing/UpdateBilling.js
+++ b/intercom/src/components/Billing/UpdateBilling.js
@@ -104,21 +104,26 @@ class UpdateBilling extends Component {
 
     render() {
         return (
-            <div className='input-group creditcard-div'>
-                <CardElement style={{ padding: "9px !important"}}/>       
-                <span className="input-group-btn">
-                    <button 
-                        className="btn btn-default" 
-                        type="button" 
-                        onClick = {this.updateCreditCard}
-                        disabled={this.state.last4 === null || this.state.processing === true}
-                    >
-                        {this.state.buttonText} 
-                    </button>
-                </span>
-                <div style = {{marginBottom:'10px'}}>
+            <div>
+
+                <div className='input-group creditcard-div'>
+                    <CardElement style={{ padding: "9px !important"}}/>       
+                    <span className="input-group-btn">
+                        <button 
+                            className="btn btn-default" 
+                            type="button" 
+                            onClick = {this.updateCreditCard}
+                            disabled={this.state.last4 === null || this.state.processing === true}
+                        >
+                            {this.state.buttonText} 
+                        </button>
+                    </span>                   
+                </div>
+
+                <div style = {{marginBottom:'10px', border:'1px solid black', height:'200px'}}>
                     {this.state.errorMessage}
                 </div>
+                
             </div>
         )
     }

--- a/intercom/src/components/Billing/UpdateBilling.js
+++ b/intercom/src/components/Billing/UpdateBilling.js
@@ -9,7 +9,7 @@ class UpdateBilling extends Component {
         super(props);
         this.state = {
             last4: '', 
-            errorMessage: '',
+            errorMessage: null,
             processing: false,
             buttonText:'Update'
         }
@@ -24,14 +24,20 @@ class UpdateBilling extends Component {
         
         try{
             const createSourceResponse = await this.props.stripe.createSource(sourceInfo);
+            // console.log('createSourceResponse: ', createSourceResponse);
 
             if (createSourceResponse.error) {
-                this.setState({errorMessage:createSourceResponse.error.message})
+                this.setState({errorMessage:createSourceResponse.error.message, processing:false, buttonText:'Update'})
+            } 
+            else{
+                this.setState({errorMessage:null})
+                const source = createSourceResponse.source;
+                // console.log('source: ', source);
+                return source;
             }
-            // console.log('createSourceResponse: ', createSourceResponse);
-            const source = createSourceResponse.source;
-            // console.log('source: ', source);
-            return source;
+
+            
+            
         } catch(err) {
             console.log('err: ', err);
             return err
@@ -88,8 +94,9 @@ class UpdateBilling extends Component {
             this.setState({processing: true, buttonText:'Processing...'})
             const source = await this.createSource();
             // console.log('source: ', source);
+            const sourceId = source.id;
             
-            const updateCreditCardRes = await axios.post(`${host}/api/billing/updateCreditCard`, {'userId': userId, 'source':source});
+            const updateCreditCardRes = await axios.post(`${host}/api/billing/updateCreditCard`, {'userId': userId, 'sourceId':sourceId});
             // console.log('updateCreditCardRes: ', updateCreditCardRes);
             this.setState({processing: false, buttonText:'Update'});
 
@@ -105,8 +112,7 @@ class UpdateBilling extends Component {
     render() {
         return (
             <div>
-
-                <div className='input-group creditcard-div'>
+                <div className='input-group creditcard-div' style = {{marginBottom:'10px'}}>
                     <CardElement style={{ padding: "9px !important"}}/>       
                     <span className="input-group-btn">
                         <button 
@@ -119,11 +125,13 @@ class UpdateBilling extends Component {
                         </button>
                     </span>                   
                 </div>
-
-                <div style = {{marginBottom:'10px', border:'1px solid black', height:'200px'}}>
-                    {this.state.errorMessage}
-                </div>
-                
+                {this.state.errorMessage
+                    ?
+                    <div style = {{color:'red', height:'20px'}}>
+                        {this.state.errorMessage}
+                    </div>
+                    :null
+                }            
             </div>
         )
     }


### PR DESCRIPTION
-When user makes an error updating their credit card, the error should pop up under updateCreditCard input box (in red text). The user should be able to see the incorrect credit card input entries when an updateCreditCard error occurs.

-The error message for addMoney errors doesn't show on the screen when an error occurs. After resolving that issue, the UI for addMoney errors should be the set up to function just like the updateCreditCard error handling UI.

-Error message should pop up if user tries to add money without having a credit card on file.